### PR TITLE
Remove unused use of 'ttyslot'

### DIFF
--- a/src/main/java/org/fusesource/jansi/internal/CLibrary.java
+++ b/src/main/java/org/fusesource/jansi/internal/CLibrary.java
@@ -63,9 +63,6 @@ public class CLibrary {
     public static native String ttyname(
             @JniArg int filedes);
 
-    @JniMethod(conditional="defined(HAVE_TTYSLOT)")
-    public static native int ttyslot();
-
     @JniMethod(conditional="defined(HAVE_OPENPTY)")
     public static native int openpty(
             @JniArg(cast="int *", flags={NO_IN}) int[] amaster,

--- a/src/main/native-package/m4/custom.m4
+++ b/src/main/native-package/m4/custom.m4
@@ -19,7 +19,6 @@ AC_DEFUN([CUSTOM_M4_SETUP],
 [
   AC_CHECK_LIB([c], [isatty],[AC_DEFINE([HAVE_ISATTY], [1], [Define to 1 if you have the isatty function.])])
   AC_CHECK_LIB([c], [ttyname],[AC_DEFINE([HAVE_TTYNAME], [1], [Define to 1 if you have the ttyname function.])])
-  AC_CHECK_LIB([c], [ttyslot],[AC_DEFINE([HAVE_TTYSLOT], [1], [Define to 1 if you have the ttyslot function.])])
   AC_CHECK_LIB([c], [openpty],[AC_DEFINE([HAVE_OPENPTY], [1], [Define to 1 if you have the openpty function.])])
   AC_CHECK_LIB([c], [tcgetattr],[AC_DEFINE([HAVE_TCGETATTR], [1], [Define to 1 if you have the tcgetattr function.])])
   AC_CHECK_LIB([c], [tcsetattr],[AC_DEFINE([HAVE_TCSETATTR], [1], [Define to 1 if you have the tcsetattr function.])])


### PR DESCRIPTION
The `CLibrary` class currently exposes the [rather obscure ttyslot](http://man7.org/linux/man-pages/man3/ttyslot.3.html) function. As far I can tell, this has never actually been used by either `jansi` or `jansi-native`. Removing it allows users of [musl libc](https://www.musl-libc.org), such as users of [Alpine Linux](https://github.com/fusesource/jansi/issues/58) to use `jansi` without any modifications.