### PR TITLE
Allow multiple architecture native builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   </parent>
 
   <groupId>org.fusesource.jansi</groupId>
-  <artifactId>jansi-${platform}</artifactId>
+  <artifactId>jansi-${platformId}</artifactId>
   <version>1.9-SNAPSHOT</version>
   
   <name>${project.artifactId}</name>
@@ -36,7 +36,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.5</maven.compiler.source>
     <hawtjni-version>1.16</hawtjni-version>
-    <platform>native</platform>    
+    <platformId>native</platformId>    
   </properties>
   
   <url>http://fusesource.github.io/${forge-project-id}</url>
@@ -123,7 +123,7 @@
         <configuration>
           <archive>
             <manifestEntries>
-              <Automatic-Module-Name>org.fusesource.jansi.${platform}</Automatic-Module-Name>
+              <Automatic-Module-Name>org.fusesource.jansi.${platformId}</Automatic-Module-Name>
             </manifestEntries>
           </archive>
         </configuration>
@@ -262,6 +262,9 @@
           <name>platform</name>
         </property>
       </activation>
+      <properties>
+        <platformId>${platform}-${arch}</platformId>
+      </properties>
       <build>
         <plugins>
           
@@ -278,7 +281,7 @@
                   <goal>package-source</goal>
                 </goals>
                 <configuration>
-                  <platform>${platform}</platform>
+                  <platform>${platform}/${arch}</platform>
                   <name>jansi</name>
                   <classified>false</classified>
                   <callbacks>false</callbacks>

--- a/readme.md
+++ b/readme.md
@@ -28,8 +28,9 @@ Project Links
 Building
 --------
 
-To build, just run `mvn -Dplatform=${platform} package` where `${platform}` may be `windows32`, `windows64`,
-`osx`, `linux32`, `linux64`, `freebsd32`, `freebsd64` or any other platform of your choice.
+To build, just run `mvn -Dplatform=${platform} -Darch=${arch} package` where `${platform}` may be `windows32`, `windows64`,
+`osx`, `linux32`, `linux64`, `freebsd32`, `freebsd64` or any other platform of your choice,
+and `${arch}` is the Java `os.name` for the target architecture, such as `i386` or `amd64`.
 
 Jansi native uses [HawtJNI](http://fusesource.github.io/hawtjni/) to ease JNI management.
 See [Platform Build Tools Requirements](http://fusesource.github.io/hawtjni/documentation/developer-guide.html#Platform_Build_Tools_Requirements)


### PR DESCRIPTION
HawtJNI's description of platform is insufficient to distinguish between
multiple architectures of the same operating system, such as Linux/amd64
and Linux/aarch64.  Renaming and relocating these resources is necessary
to create jars which will cover all available OS/arch combinations.